### PR TITLE
Support ESP-IDF 6.1 DSI bus flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `QueueSet2`, `QueueSet3`, `QueueSet4` for waiting on multiple heterogeneous queues
 - Basic compatibility for ESP-IDF release 6.0.
 - I2S Standard, PDM and TDM Mode Driver dynamic reconfiguration (change sample rate)
+- Support ESP-IDF 6.1 DSI bus flags and continuous high-speed clock-lane configuration.
 
 ### Breaking
 - I2S: `ClockSource::Apll` and `ClockSource::Xtal` on `esp32p4`, where the XTAL is now the default for this chip

--- a/src/lcd.rs
+++ b/src/lcd.rs
@@ -144,6 +144,10 @@ pub mod config {
                 num_data_lanes,
                 phy_clk_src: soc_module_clk_t_SOC_MOD_CLK_PLL_F160M as u32,
                 lane_bit_rate_mbps: lane_bit_rate_mbps as _,
+                #[cfg(esp_idf_version_at_least_6_1_0)]
+                // SAFETY: zero initializes the optional flags and preserves ESP-IDF's
+                // default automatic clock-lane mode.
+                flags: unsafe { core::mem::zeroed() },
             };
 
             let dbi_config = esp_lcd_dbi_io_config_t {
@@ -195,6 +199,18 @@ pub mod config {
         #[must_use]
         pub fn phy_clk_src(mut self, phy_clk_src: u32) -> Self {
             self.bus_config.phy_clk_src = phy_clk_src;
+            self
+        }
+
+        /// Force the DSI clock lane to remain in high-speed mode.
+        ///
+        /// By default, ESP-IDF automatically switches the clock lane between
+        /// high-speed and low-power states. Enable this only for panels that
+        /// require a continuously running high-speed clock lane.
+        #[cfg(esp_idf_version_at_least_6_1_0)]
+        #[must_use]
+        pub fn clock_lane_force_hs(mut self, force: bool) -> Self {
+            self.bus_config.flags.set_clock_lane_force_hs(force as u32);
             self
         }
 


### PR DESCRIPTION
## Thank you for your contribution!

We appreciate the time and effort you've put into this pull request.
To help us review it efficiently, please ensure you've gone through the following checklist:

### Submission Checklist 📝

- [x] I have updated existing examples or added new ones (not applicable: the existing DSI example should retain ESP-IDF's default automatic clock-lane behavior).
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
- [x] My changes were added to the `CHANGELOG.md` in the proper section.

### Pull Request Details 📖

#### Description

ESP-IDF 6.1 added a `flags` field to `esp_lcd_dsi_bus_config_t`, causing the existing `LcdConfig` initializer to fail to compile against ESP-IDF 6.1.

This change:

- initializes the new field to zero on ESP-IDF 6.1 and later, preserving ESP-IDF's default automatic HS/LP clock-lane switching;
- adds a `clock_lane_force_hs(bool)` builder method for panels that require the DSI clock lane to remain in high-speed mode;
- gates both changes on `esp_idf_version_at_least_6_1_0`, preserving compatibility with earlier ESP-IDF versions.

#### Testing

- Ran `cargo fmt -- --check`.
- Ran Clippy and the standard, `no_std`, `no_std` with allocation, and example builds for `riscv32imafc-esp-espidf` with ESP-IDF `release/v6.1`. The relevant ESP32-P4 job passed all steps:
  https://github.com/bobotu/esp-idf-hal/actions/runs/33230906231/job/99043454768
- Completed clean release builds of two downstream ESP32-P4 applications using the official local ESP-IDF 6.1 installation.

CI note: `.github/workflows/ci-esp-idf-next.yml` already tests ESP-IDF
`release/v6.1`, but its target matrix does not currently include
`riscv32imafc-esp-espidf` (ESP32-P4). Therefore, the upstream workflows do not
exercise this specific ESP32-P4/ESP-IDF 6.1 combination.

I validated that combination using the fork-only job linked above and kept this
PR code-only to avoid expanding the scheduled matrix. Adding ESP32-P4 to the
`CIEspIdfNext` matrix would also exercise ESP-IDF `master`, which currently has
an unrelated `usb_serial_jtag_driver_config_t::intr_priority` compatibility
failure.