### PR TITLE
gpio: route the pad to GPIO before setting a pin's direction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- `PinDriver` now routes the pad to the GPIO function before setting its direction. A pin whose `IO_MUX.MCU_SEL` boots on an alternate function - JTAG, SPI flash, UART - stayed on that function, so `set_high`/`set_low` never reached the pad (#585)
 - Fixed issue 502 - some ADC/RTC pins for esp32c5 and esp32c6 had mapping errors
 - Fixed async SPI transactions occasionally hanging forever on multi-core chips
 - SPI: `SpiBusDriver::new` no longer leaves the device attached to the bus when acquiring the bus lock fails. The device used to stay registered, so freeing the bus later failed with `ESP_ERR_INVALID_STATE` ("not all CSses freed") and panicked in `SpiDriver`'s destructor

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -1065,6 +1065,14 @@ impl<'d, MODE> PinDriver<'d, MODE> {
         MODE: GPIOMode,
     {
         if mode != gpio_mode_t_GPIO_MODE_DISABLE {
+            // `gpio_set_direction` wires up the GPIO matrix and the output
+            // enable, but it never touches `IO_MUX.MCU_SEL`. A pad that boots
+            // on an alternate function - JTAG, SPI flash, UART - therefore
+            // stays on that function and never sees what the driver writes.
+            // Route it to the GPIO function first, which is what `gpio_config`
+            // does for every pin it is handed.
+            unsafe { esp_rom_gpio_pad_select_gpio(pin as _) };
+
             esp!(unsafe { gpio_set_direction(pin as _, mode) })?;
         }
 


### PR DESCRIPTION
### Submission Checklist 📝

- [x] I have updated existing examples or added new ones (if applicable).
  *Not applicable — no API change.* The seven examples that use `PinDriver::output`/`input_output` (`blinky`, `blinky_async`, `button`, `button_async`, `button_interrupt`, `spi_st7789`, `rmt_transceiver`) are unmodified and simply become correct on pins whose `MCU_SEL` does not boot as `PIN_FUNC_GPIO`. A new example would only restate the bug.
- [x] I have used `cargo fmt` command to ensure that all changed code is formatted correctly.
  `cargo fmt -- --check` — clean.
- [x] I have used `cargo clippy` command to ensure that all changed code passes latest Clippy nightly lints.
  The CI command verbatim, on both architectures, against ESP-IDF v5.5.5 — clean under `-Dwarnings`:
  ```
  cargo clippy --features experimental --no-deps --target xtensa-esp32s3-espidf  -Zbuild-std=std,panic_abort -- -Dwarnings
  cargo clippy --features experimental --no-deps --target riscv32imc-esp-espidf  -Zbuild-std=std,panic_abort -- -Dwarnings
  ```
  `clippy 0.1.95 (95e5bda868 2026-04-15)`. RISC-V was included deliberately: #585 reports the bug on an ESP32-C3.
- [x] My changes were added to the `CHANGELOG.md` in the **_proper_** section.
  Under `## [Unreleased]` → `### Fixed`.

---

## Description

Fixes the bug behind our week-long dark-LED hunt, and answers both questions the upstream maintainer asked on esp-rs/esp-idf-hal#585.

## The bug

`PinDriver::output` calls only `gpio_set_direction`, which wires up the GPIO matrix and the output enable but never writes `IO_MUX.MCU_SEL`. A pad that comes out of reset on an alternate function stays on it, so `set_high` reaches the matrix and stops there. `is_set_high` still returns `true`, because it reads the matrix rather than the pad, which is what makes this so hard to see from the firmware side.

Every other peripheral is unaffected because RMT, LEDC, I2C and friends call `gpio_config` or `esp_rom_gpio_pad_select_gpio` in their own init. MicroPython is unaffected because `machine.Pin` goes through `gpio_config`. Only a bare `PinDriver` is exposed.

## It is a regression, and here is where

The maintainer asked "check when this regression was introduced, if that's a regression". It is, and it came in with #529 (`2af4695`, *Remove Peripheral/PeripheralRef*, 2025-09-03), first released in **v0.46.0**.

Before that, `PinDriver::output` did this:

```rust
pub fn output(pin: impl Peripheral<P = T> + 'd) -> Result<Self, EspError> {
    crate::into_ref!(pin);
    Self { pin, _mode: PhantomData }.into_output()   // -> into_mode()
}

fn into_mode<M>(mut self, mode: gpio_mode_t) -> Result<PinDriver<'d, T, M>, EspError> {
    let pin = unsafe { self.pin.clone_unchecked() };
    drop(self);                                       // <-- Drop -> gpio_reset_without_pull -> gpio_config
    if mode != gpio_mode_t_GPIO_MODE_DISABLE {
        esp!(unsafe { gpio_set_direction(pin.pin(), mode) })?;
    }
    ...
}
```

The pad routing was never deliberate - it was a side effect of `drop(self)` running `gpio_reset_without_pull`, whose `gpio_config` ends with

```c
/* By default, all the pins have to be configured as GPIO pins. */
gpio_hal_func_sel(gpio_context.gpio_hal, io_num, PIN_FUNC_GPIO);
```

#529 collapsed that dance into `new_gpio(pin, mode)`, which calls `gpio_set_direction` alone. The reset went, and the pad routing went with it.

That also explains why it took until v0.46.0 for anyone to notice: `Drop` still calls `gpio_config`, so a pin taken, dropped and taken again works. Only the **first** acquisition of a pin whose `MCU_SEL` did not boot as `PIN_FUNC_GPIO` is broken.

## Second confirmation, different silicon

esp-rs/esp-idf-hal#585 reports it on an ESP32-C3, GPIO5, ESP-IDF 5.3.3.
I've hit the same thing independently on an **ESP32-S3, GPIO40** under ESP-IDF 5.5.5 - GPIO40 is MTDO and boots on the JTAG function, so it is broken every single boot rather than by luck of the reset value. It gates the 5 V rail of our LED ring through a MOSFET, so the symptom was simply that the ring never lit.

Measured on the pad with `set_high()` returning `Ok(())`:

```
GPIO_OUT_REG    bit 40 = 1
GPIO_ENABLE_REG bit 40 = 1
IO_MUX_GPIO40_REG      = 0x00000100
  MCU_SEL (14:12) = 0     <- JTAG (MTDO), not PIN_FUNC_GPIO
pad                    = 0 V
```

So the report is not C3-specific and not IDF-version-specific.

## The fix

One ROM call in `new_gpio`, ahead of `gpio_set_direction`. `esp_rom_gpio_pad_select_gpio` is the narrowest thing that does the job: it sets `MCU_SEL` and nothing else, so it does not disturb pulls, which is what #344 went out of its way to stop `PinDriver` from doing.

Reaching for `gpio_config` instead would restore the pre-#529 behaviour more literally, but it would also rewrite pull-up, pull-down, interrupt type and hysteresis at construction, and #344 deliberately moved away from that.

## Testing

- ESP32-S3, GPIO40 (MTDO), ESP-IDF v5.5.5.
  - Before: pad at 0 V with `GPIO_OUT` and `GPIO_ENABLE` both set and `IO_MUX_GPIO40_REG` = `0x00000100` (`MCU_SEL` = 0, JTAG).
  - After: pad drives high and the 5 V rail it gates comes up.
- **Regression bisected**: `git blame` and the pre-#529 source both confirm the pad routing used to come from `drop(self)` inside `into_mode`.