### PR TITLE
rmt: fix a real ISR-context panic/abort in EncoderState's rmt_encode_state_t conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue 502 - some ADC/RTC pins for esp32c5 and esp32c6 had mapping errors
 - Fixed async SPI transactions occasionally hanging forever on multi-core chips
 - SPI: `SpiBusDriver::new` no longer leaves the device attached to the bus when acquiring the bus lock fails. The device used to stay registered, so freeing the bus later failed with `ESP_ERR_INVALID_STATE` ("not all CSses freed") and panicked in `SpiDriver`'s destructor
+- Fix a real, live-hardware-reproduced panic in `rmt::encoder::EncoderState`'s
+  `From<rmt_encode_state_t>` conversion, surfacing as an unexplained ESP-IDF `abort()` rather than
+  a normal panic message, since the panic occurs inside the RMT ISR where Rust's panic handling
+  can't safely lock/print (newlib's own lock code detects the invalid ISR-context lock attempt and
+  aborts instead). `rmt_encode_state_t` is a genuine C bitmask (`RMT_ENCODING_RESET = 0`,
+  `RMT_ENCODING_COMPLETE = (1 << 0)`, `RMT_ENCODING_MEM_FULL = (1 << 1)`,
+  `RMT_ENCODING_WITH_EOF = (1 << 2)`), but `EncoderState` modeled the individual flags as
+  mutually-exclusive enum variants, which panicked on any combined value it hadn't special-cased.
+  Confirmed on real hardware this isn't an edge case: a small WS2812-strip transmission that
+  finishes encoding while also exactly filling the remaining RMT memory block produces
+  `COMPLETE | MEM_FULL` on its last encode step - a different combination than the also-valid
+  `COMPLETE | WITH_EOF`, and not necessarily the only one.
 
 ### Added
 - `QueueSet2`, `QueueSet3`, `QueueSet4` for waiting on multiple heterogeneous queues
@@ -22,6 +34,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Breaking
 - I2S: `ClockSource::Apll` and `ClockSource::Xtal` on `esp32p4`, where the XTAL is now the default for this chip
 - Dropped support for RGB/BGR666 format on ESP-IDF 6.0.
+
+### Changed (breaking)
+- `rmt::encoder::EncoderState` is now a bitmask wrapper type instead of an enum, matching the C
+  type it mirrors and able to represent any real flag combination without panicking:
+  `EncoderState::EncodingComplete`/`EncodingMemoryFull`/`EncodingReset`/`EncodingWithEof` are
+  replaced by associated consts `EncoderState::COMPLETE`/`MEM_FULL`/`RESET`/`WITH_EOF`, combinable
+  via `|` (`impl BitOr`), and by query methods `is_complete()`/`is_mem_full()`/`is_reset()`/
+  `has_eof()` in place of matching on a variant.
 
 ## [0.46.2] - 2026-03-10
 

--- a/examples/rmt_loop_encoder.rs
+++ b/examples/rmt_loop_encoder.rs
@@ -76,7 +76,7 @@ mod example {
                 state = current_state;
 
                 // If the inner encoder completed, one count has been completed.
-                if let EncoderState::EncodingComplete = state {
+                if state.is_complete() {
                     // only increment the count if there is a target, otherwise it might crash in debug mode because of overflow
                     if self.target.is_some() {
                         self.count += 1;

--- a/src/rmt/encoder.rs
+++ b/src/rmt/encoder.rs
@@ -45,45 +45,90 @@ impl<E: RawEncoder> RawEncoder for &mut E {
     }
 }
 
-/// RMT encoding state
-#[derive(Debug, Clone)]
-#[non_exhaustive]
-pub enum EncoderState {
-    /// The encoding session is in reset state
-    EncodingReset,
-    /// The encoding session is finished, the caller can continue with subsequent encoding
-    EncodingComplete,
+/// RMT encoding state.
+///
+/// `rmt_encode_state_t` (see `rmt_encoder.h`) is a genuine C bitmask, not a plain enum:
+/// `RMT_ENCODING_RESET = 0`, `RMT_ENCODING_COMPLETE = (1 << 0)`,
+/// `RMT_ENCODING_MEM_FULL = (1 << 1)`, `RMT_ENCODING_WITH_EOF = (1 << 2)`, and the real driver is
+/// free to OR any of these together in one return value. This used to be modeled as a set of
+/// mutually-exclusive enum variants, which is fundamentally the wrong shape for a bitmask type:
+/// converting a real, valid combined value back from C hit an unreachable-in-theory wildcard arm
+/// and panicked - and because this conversion runs inside the RMT ISR (see [`Encoder::encode`]'s
+/// own "ISR Safety" note), a Rust panic can't safely lock/print there, so ESP-IDF's own newlib
+/// lock code detects the invalid ISR-context lock attempt and calls `abort()` instead of printing
+/// a readable panic message - a real, live-hardware-reproduced crash, not a theoretical concern.
+/// Confirmed (via a temporary ISR-safe `esp_rom_printf` probe, since normal panic output is what
+/// breaks in this exact ISR-context scenario) that combined values are not an edge case: a small
+/// WS2812-strip transmission that finishes encoding at the same time it exactly fills the
+/// remaining RMT memory block reports `RMT_ENCODING_COMPLETE | RMT_ENCODING_MEM_FULL` (value `3`)
+/// on real hardware - a different combination than the also-valid `COMPLETE | WITH_EOF`, and not
+/// necessarily the only one either. A plain enum cannot represent an unbounded set of flag
+/// combinations without either growing a variant per combination forever or panicking on whichever
+/// one it hasn't special-cased yet, which is exactly the bug this type had. Modeled as a thin
+/// bitmask wrapper instead, matching the C type it mirrors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EncoderState(rmt_encode_state_t);
+
+impl EncoderState {
+    /// The encoding session is in reset state.
+    pub const RESET: Self = Self(rmt_encode_state_t_RMT_ENCODING_RESET);
+    /// The encoding session is finished, the caller can continue with subsequent encoding.
+    pub const COMPLETE: Self = Self(rmt_encode_state_t_RMT_ENCODING_COMPLETE);
     /// The encoding artifact memory is full, the caller should return from current encoding session.
-    EncodingMemoryFull,
-    /// The encoding session has inserted the EOF marker to the symbol stream
+    pub const MEM_FULL: Self = Self(rmt_encode_state_t_RMT_ENCODING_MEM_FULL);
+    /// The encoding session has inserted the EOF marker to the symbol stream.
     #[cfg(esp_idf_version_at_least_5_5_0)]
     #[cfg_attr(feature = "nightly", doc(cfg(esp_idf_version_at_least_5_5_0)))]
-    EncodingWithEof,
+    pub const WITH_EOF: Self = Self(rmt_encode_state_t_RMT_ENCODING_WITH_EOF);
+
+    /// Whether this is the reset state (no other flag can be combined with it - `RESET` is `0`).
+    #[must_use]
+    pub const fn is_reset(&self) -> bool {
+        self.0 == rmt_encode_state_t_RMT_ENCODING_RESET
+    }
+
+    /// Whether the [`COMPLETE`](Self::COMPLETE) flag is set - may also have
+    /// [`MEM_FULL`](Self::MEM_FULL) and/or [`WITH_EOF`](Self::WITH_EOF) set at the same time.
+    #[must_use]
+    pub const fn is_complete(&self) -> bool {
+        self.0 & rmt_encode_state_t_RMT_ENCODING_COMPLETE != 0
+    }
+
+    /// Whether the [`MEM_FULL`](Self::MEM_FULL) flag is set - may also have
+    /// [`COMPLETE`](Self::COMPLETE) set at the same time (the last chunk of a session can both
+    /// finish encoding and exactly fill the remaining memory block in the same call).
+    #[must_use]
+    pub const fn is_mem_full(&self) -> bool {
+        self.0 & rmt_encode_state_t_RMT_ENCODING_MEM_FULL != 0
+    }
+
+    /// Whether the [`WITH_EOF`](Self::WITH_EOF) flag is set.
+    #[cfg(esp_idf_version_at_least_5_5_0)]
+    #[cfg_attr(feature = "nightly", doc(cfg(esp_idf_version_at_least_5_5_0)))]
+    #[must_use]
+    pub const fn has_eof(&self) -> bool {
+        self.0 & rmt_encode_state_t_RMT_ENCODING_WITH_EOF != 0
+    }
+}
+
+impl core::ops::BitOr for EncoderState {
+    type Output = Self;
+
+    /// Combines two encoding-state flags, e.g. `EncoderState::COMPLETE | EncoderState::WITH_EOF`.
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
 }
 
 impl From<EncoderState> for rmt_encode_state_t {
     fn from(value: EncoderState) -> Self {
-        match value {
-            EncoderState::EncodingReset => rmt_encode_state_t_RMT_ENCODING_RESET,
-            EncoderState::EncodingComplete => rmt_encode_state_t_RMT_ENCODING_COMPLETE,
-            EncoderState::EncodingMemoryFull => rmt_encode_state_t_RMT_ENCODING_MEM_FULL,
-            #[cfg(esp_idf_version_at_least_5_5_0)]
-            EncoderState::EncodingWithEof => rmt_encode_state_t_RMT_ENCODING_WITH_EOF,
-        }
+        value.0
     }
 }
 
 impl From<rmt_encode_state_t> for EncoderState {
     fn from(value: rmt_encode_state_t) -> Self {
-        #[allow(non_upper_case_globals)]
-        match value {
-            rmt_encode_state_t_RMT_ENCODING_RESET => Self::EncodingReset,
-            rmt_encode_state_t_RMT_ENCODING_COMPLETE => Self::EncodingComplete,
-            rmt_encode_state_t_RMT_ENCODING_MEM_FULL => Self::EncodingMemoryFull,
-            #[cfg(esp_idf_version_at_least_5_5_0)]
-            rmt_encode_state_t_RMT_ENCODING_WITH_EOF => Self::EncodingWithEof,
-            _ => panic!("Unknown rmt_encode_state_t value: {value}"),
-        }
+        Self(value)
     }
 }
 
@@ -141,13 +186,13 @@ pub trait Encoder {
     /// This function might be called multiple times within a single transaction.
     /// The encode function should return the state of the current encoding session.
     ///
-    /// The supported states are listed in [`EncoderState`]. If the result contains
-    /// [`EncoderState::EncodingComplete`], it means the current encoder has finished
-    /// work.
+    /// The supported states are listed in [`EncoderState`]. If the result has
+    /// [`EncoderState::is_complete`] true, it means the current encoder has finished work (this
+    /// may be combined with either of the flags below in the same result - see [`EncoderState`]'s
+    /// own doc comment).
     ///
-    /// If the result contains [`EncoderState::EncodingMemoryFull`], the program needs
-    /// to yield from the current session, as there is no space to save more encoding
-    /// artifacts.
+    /// If the result has [`EncoderState::is_mem_full`] true, the program needs to yield from the
+    /// current session, as there is no space to save more encoding artifacts.
     ///
     /// # Note
     ///
@@ -182,7 +227,7 @@ impl<E: RawEncoder> Encoder for E {
     ) -> (usize, EncoderState) {
         let encoder_handle = self.handle();
         let Some(encode) = encoder_handle.encode else {
-            return (0, EncoderState::EncodingReset);
+            return (0, EncoderState::RESET);
         };
 
         let mut ret_state: rmt_encode_state_t = rmt_encode_state_t_RMT_ENCODING_RESET;


### PR DESCRIPTION
## Summary

`rmt_encode_state_t` (`rmt_encoder.h`) is a genuine C bitmask, not a plain enum:

```c
typedef enum {
    RMT_ENCODING_RESET = 0,
    RMT_ENCODING_COMPLETE = (1 << 0),
    RMT_ENCODING_MEM_FULL = (1 << 1),
    RMT_ENCODING_WITH_EOF = (1 << 2),
} rmt_encode_state_t;
```

The real driver is free to OR these together in one return value, but `EncoderState`'s `From<rmt_encode_state_t>` modeled the individual flags as mutually-exclusive enum variants and panicked on any combined value it didn't recognize.

Because this conversion runs inside the RMT ISR (see `Encoder::encode`'s own "ISR Safety" doc note), a Rust panic can't safely lock/print there - ESP-IDF's own newlib lock code detects the invalid ISR-context lock attempt the panic's print path needs and calls `abort()` instead of printing a readable panic message. This surfaces as an unexplained device crash-loop (`abort() was called at PC ...`), not a panic message - which is what made it hard to diagnose without a debug build and manual `addr2line` correlation.

## Confirmed on real hardware

Found via a real WS2812 LED strip driver upgrade (an ESP32 classic / Ulanzi TC001 board, ESP-IDF 5.5.3) from the legacy RMT API to this new one - the very first `show()` call crashed the device in a continuous reboot loop.

Root-caused via `addr2line` against a debug-info build, tracing the abort backtrace through `lock_acquire_generic` → `_lock_acquire_recursive` → UART/console write → Rust panic machinery → `core::panicking::panic_fmt` → `InternalEncoderWrapper::encode` → `rmt_encode_check_result` → `rmt_isr_handle_tx_threshold` → `rmt_tx_default_isr`.

Confirmed this isn't a single special-cased combination: with a temporary ISR-safe `esp_rom_printf` probe (normal panic output being exactly what breaks in this scenario), a small WS2812-strip transmission that finishes encoding while also exactly filling the remaining RMT memory block reports `RMT_ENCODING_COMPLETE | RMT_ENCODING_MEM_FULL` (value `3`) on its last encode step - a different combination than the also-valid `COMPLETE | WITH_EOF`. An initial attempt at this fix that only special-cased `COMPLETE | WITH_EOF` as one new enum variant reproduced the same class of crash on this second, different combination, confirming a plain enum (even with additional variants) is the wrong shape for a bitmask, not just missing one case.

## Fix

Reworks `EncoderState` as a thin bitmask wrapper (matching the C type it mirrors) instead of an enum:

- `EncodingComplete` / `EncodingMemoryFull` / `EncodingReset` / `EncodingWithEof` variants become associated consts `EncoderState::COMPLETE` / `MEM_FULL` / `RESET` / `WITH_EOF`.
- Combinable via `|` (`impl BitOr for EncoderState`).
- `is_complete()` / `is_mem_full()` / `is_reset()` / `has_eof()` query methods replace variant matching.
- Can represent any real flag combination (present or future) without panicking.

This is a breaking API change for anyone matching on `EncoderState` variants directly, but the previous shape was unsound for its own stated purpose (representing a C bitmask) - happy to adjust the exact shape (e.g. `bitflags`-crate-based instead of hand-rolled) if maintainers prefer.

## Testing

- Verified `cargo check`/`clippy -D warnings`/`cargo fmt --check` clean against the `xtensa-esp32-espidf` target (via a downstream crate with this pinned as a `[patch.crates-io]` path/git dependency).
- Verified live on real hardware (Ulanzi TC001 / ESP32 classic): clean boot, a 200-second continuous run with no crash/panic/abort markers in the serial log, versus a 100% reproducible crash-loop before this fix (within milliseconds of the first `show()` call, every time).
- Updated the one example (`examples/rmt_loop_encoder.rs`) and `CHANGELOG.md` accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FFnG1meWc3JEagSp2dzkeF